### PR TITLE
Fixes

### DIFF
--- a/man/read_econdata.Rd
+++ b/man/read_econdata.Rd
@@ -77,7 +77,7 @@ ELECTRICITY <- read_econdata(id = "ELECTRICITY")
 ELECTRICITY_WIDE <- econdata_tidy(ELECTRICITY) # Or: read_econdata("ELECTRICITY", tidy = TRUE)
 ELECTRICITY_LONG <- econdata_tidy(ELECTRICITY, wide = FALSE)
 # Same as econdata_tidy(ELECTRICITY, wide = FALSE, combine = TRUE):
-with(ELECTRICITY_LONG, metadata[data, on = "code"])
+with(ELECTRICITY_LONG, metadata[data, on = "data_key"])
 
 # CPI Analytical Series: Different Revisions
 CPI_ANL <- read_econdata(id = "CPI_ANL_SERIES")

--- a/man/read_release.Rd
+++ b/man/read_release.Rd
@@ -58,7 +58,7 @@ BA900_RELEASE <- read_release(id = "BA900")
 econdata_tidy(BA900_RELEASE, release = TRUE)      # No further options supported.
 
 # Releases for all CPI Revisions
-read_econdata(id = "CPI_ANL_SERIES", tidy = TRUE)
+read_release(id = "CPI_ANL_SERIES", tidy = TRUE)
 }
 }
 % Add one or more standard keywords, see file 'KEYWORDS' in the


### PR DESCRIPTION
For multiple versions of the same dataset, e.g. `read_econdata(id = "CPI_ANL_SERIES", tidy = TRUE)` gets v2.0, v2.1 and v2.2 of the CPI, `econdata_wide()` and `econdata_long()` (workhorses of `econdata_tidy()`) were designed to call themselves, i.e. they are recursive functions. Your prettymeta coding did not respect this i.e. it only worked for a single version of a dataset. I have here adjusted the code a bit to allow getting multiple versions of the same dataset with pretty metadata. Your coding also broke some of my examples, which I fixed here. Finally, I implemented the metadata matching for loops in a slightly more efficient way (indexing data.frame's in a loop is not ideal, plain lists are much more efficient). 